### PR TITLE
chore: automated PR reviews + dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,52 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            First decide which review track applies:
+
+            DEPENDABOT TRACK — if the PR author is "dependabot[bot]":
+              - Read the PR title, body, and diff with `gh pr view ${{ github.event.pull_request.number }}` and `gh pr diff ${{ github.event.pull_request.number }}`.
+              - Identify whether the bump is patch, minor, or major.
+              - Skim the linked release notes / changelog from the PR body for breaking changes.
+              - Check that the diff is limited to manifest + lockfile (no unrelated source changes).
+              - Decision rules:
+                  • Patch: approve unless the changelog explicitly calls out a breaking change in this version.
+                  • Minor: approve if changelog has no "breaking" / "BREAKING CHANGE" / removed-API language; otherwise request changes.
+                  • Major: request changes by default and ask for human review unless the changelog is unambiguously additive (rare).
+                  • Group PRs (multiple bumps): apply the strictest rule across all members.
+                  • If diff touches anything beyond lockfile + manifest: request changes.
+              - Submit the formal review with the gh CLI (NOT a plain comment):
+                  gh pr review ${{ github.event.pull_request.number }} --approve --body "<one-sentence reasoning>"
+                  OR
+                  gh pr review ${{ github.event.pull_request.number }} --request-changes --body "<what needs human attention>"
+
+            STANDARD TRACK — for any other author:
+              - Do a normal code review: correctness, security, tests, readability.
+              - Leave inline comments via mcp__github_inline_comment__create_inline_comment for specific issues.
+              - Submit a top-level review summary with `gh pr review --comment --body "..."`. Do NOT auto-approve human PRs.
+
+            Be terse. No emoji. No filler.
+          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(gh api:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,4 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: |
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/claude.yml` — responds to `@claude` mentions on issues/PRs/review comments via `anthropics/claude-code-action@v1`.
- Add `.github/workflows/claude-code-review.yml` — runs on every PR. For Dependabot PRs, formally approves (`gh pr review --approve`) safe bumps and requests changes on majors / unsafe diffs. For human PRs, leaves a non-blocking summary comment.
- Add `.github/workflows/dependabot-auto-merge.yml` — listens for `pull_request_review: approved` from Dependabot PRs and runs `gh pr merge --auto --squash`.

## Prerequisites (already done)

- `ANTHROPIC_API_KEY` secret available (per-repo for personal repos, org-level for ITGuys-RO).
- `Allow auto-merge` enabled.
- `Automatically delete head branches` enabled.

## Why no branch protection

Auto-merge fires on Claude approval rather than CI gating, so direct pushes to the default branch keep working. CI still runs on PRs as a safety net but doesn't block.