### PR TITLE
ci: add central tests, gate deploy on them passing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,16 @@ on:
     branches: [ main ]
 
 jobs:
+  tests:
+    permissions:
+      contents: read
+    uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v1
+    with:
+      script-typecheck: type-check
+
   validate:
     name: Validate (Type Check & Wrangler)
+    needs: tests
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    permissions:
+      contents: read
+    uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v1
+    with:
+      script-typecheck: type-check


### PR DESCRIPTION
## Summary
- New `tests.yml` workflow runs central type-check on PRs via `dustfeather/shared-workflows/.github/workflows/node-test.yml@v1`
- Passes `script-typecheck: type-check` because this repo uses the hyphenated script name (the central workflow defaults to `typecheck`)
- `deploy.yml`: added a `tests` reusable-workflow job and made `validate` depend on it via `needs: tests`, transitively gating `deploy` and `post-deploy`
- Node 24 is already pinned everywhere (3x in `deploy.yml`, `.nvmrc`, `package.json#engines`); no version bumps needed

## Test plan
- [ ] CI runs the new `Tests` workflow on this PR and it passes
- [ ] On merge to `main`, `deploy.yml` runs `tests` first; `validate`/`deploy`/`post-deploy` only run after `tests` succeeds