### PR TITLE
ci: cancel pr-checks on PR close/merge

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: PR checks
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
     paths-ignore:
       - '.github/workflows/pr-checks.yml'
 
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   tests:
+    if: github.event.action != 'closed'
     permissions:
       contents: read
     uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v1
@@ -22,6 +23,7 @@ jobs:
       script-typecheck: type-check
 
   review:
+    if: github.event.action != 'closed'
     needs: tests
     permissions:
       contents: read


### PR DESCRIPTION
Adds `closed` to `pull_request.types` and gates each job with `if: github.event.action != '\''closed'\''`. The closed event shares the concurrency group with the in-flight run, which gets cancelled via `cancel-in-progress: true`. The new run's jobs all skip. Net: no Claude tokens spent reviewing PRs that have already been merged.

Same one-line pattern across all 12 repos.