### PR TITLE
ci: auto-rebase-merge PRs on approval

### DIFF
--- a/.github/workflows/merge-on-approval.yml
+++ b/.github/workflows/merge-on-approval.yml
@@ -1,0 +1,23 @@
+name: Merge on approval
+
+# When a PR gets an approving review — including the approval the
+# claude-code-review job submits as claude[bot] via `gh pr review --approve`
+# — land it via the shared reusable workflow (rebase-merge, auto mode).
+# claude[bot] is a GitHub App, so its review DOES trigger this workflow
+# (only the default GITHUB_TOKEN is blocked from cascading events).
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  merge:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: dustfeather/shared-workflows/.github/workflows/merge-on-approval.yml@v2
+    with:
+      runner: arc-df-fear-greed-telegram-bot


### PR DESCRIPTION
Wires `dustfeather/shared-workflows/merge-on-approval.yml@v2`. An approving review (incl. the `claude[bot]` review-job approval) lands the PR via `gh pr merge --auto --rebase --delete-branch`. Auto-merge feature is enabled and repo is rebase-only. No secrets needed (implicit GITHUB_TOKEN). Runner: `arc-df-fear-greed-telegram-bot`.