### PR TITLE
chore: bump shared-workflows reusable workflows to v4

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,7 @@ jobs:
       issues: read
       id-token: write
       actions: read
-    uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v4
     with:
       runner: arc-df-fear-greed-telegram-bot
     secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: dustfeather/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v4
     with:
       runner: arc-df-fear-greed-telegram-bot

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     permissions:
       contents: read
-    uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v4
     with:
       runner: arc-df-fear-greed-telegram-bot
       script-typecheck: type-check

--- a/.github/workflows/merge-on-approval.yml
+++ b/.github/workflows/merge-on-approval.yml
@@ -18,6 +18,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: dustfeather/shared-workflows/.github/workflows/merge-on-approval.yml@v2
+    uses: dustfeather/shared-workflows/.github/workflows/merge-on-approval.yml@v4
     with:
       runner: arc-df-fear-greed-telegram-bot

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.action != 'closed'
     permissions:
       contents: read
-    uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v4
     with:
       runner: arc-df-fear-greed-telegram-bot
       script-typecheck: type-check
@@ -31,7 +31,7 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
-    uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v4
     with:
       runner: arc-df-fear-greed-telegram-bot
     secrets: inherit


### PR DESCRIPTION
Bumps all shared-workflows reusable workflow references from v2/v3 to v4.